### PR TITLE
[PetPet] Change option type from User & Role => User

### DIFF
--- a/plugins/petpet/src/index.ts
+++ b/plugins/petpet/src/index.ts
@@ -18,7 +18,7 @@ export default {
                 {
                     name: "user",
                     description: "name or id of the user",
-                    type: 9,
+                    type: 6,
                     required: true,
                     displayName: "User",
                     displayDescription: "Name or Id of the user",


### PR DESCRIPTION
If you pass a ROLE id to the user option, it wouldn't crash and xplode the whole client, yeah, but it shouldn't even accept them. Even though Discord isn't handling it properly right now, hopefully they will in future. :bleh: