### PR TITLE
[PetPet] Conform to Discord's application command naming for consistency & reword descriptions

### DIFF
--- a/plugins/petpet/src/index.ts
+++ b/plugins/petpet/src/index.ts
@@ -5,23 +5,22 @@ const UserStore = findByStoreName("UserStore");
 const { sendAttachments } = findByProps("sendAttachments");
 let command;
 
-
 export default {
     onLoad: () => {
         command = registerCommand({ 
             name: "petpet",
-            displayName: "PetPet",
-            displayDescription: "pet someone with a petpet",
-            description: "pet someone with a petpet",
+            displayName: "petpet",
+            displayDescription: "PetPet someone",
+            description: "PetPet someone",
 
             options: [
                 {
                     name: "user",
-                    description: "name or id of the user",
+                    description: "The user(or their id) to be patted",
                     type: 6,
                     required: true,
-                    displayName: "User",
-                    displayDescription: "Name or Id of the user",
+                    displayName: "user",
+                    displayDescription: "The user(or their id) to be patted",
                 }
             ],
 


### PR DESCRIPTION
> If there is a lowercase variant of any letters used, you must use those. Characters with no lowercase variants and/or uncased letters are still allowed.
- [Source](https://discord.com/developers/docs/interactions/application-commands#:~:text=If%20there%20is%20a%20lowercase%20variant%20of%20any%20letters%20used%2C%20you%20must%20use%20those.%20Characters%20with%20no%20lowercase%20variants%20and/or%20uncased%20letters%20are%20still%20allowed.)